### PR TITLE
Support all ruby files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,8 @@ export function activate(context: vscode.ExtensionContext) {
     const documentFilters = [
         { language: 'haml', scheme: 'file' },
         { language: 'erb', scheme: 'file' },
-        { language: 'slim', scheme: 'file' }
+        { language: 'slim', scheme: 'file' },
+        { language: 'ruby', scheme: 'file' },
     ];
 
     context.subscriptions.push(vscode.languages.registerHoverProvider(documentFilters, new I18nHoverProvider()));


### PR DESCRIPTION
Allow `Go to definition` to work with ruby files.

My first vscode extension contribution, feedback required

Related to #10 