### PR TITLE
Make languages configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Rails I18n helper for Visual Studio Code
 
 ## Features
 
-- supported template languages: haml, erb and slim
+- default supported template languages: haml, erb and slim
+  - others can be configured by adding the language identifier to the `railsI18n.languageIdentifiers` setting
 - shows translation (in default locale) when hovering over i18n keys in view files
 
 ![alt text](https://github.com/shanehofstetter/rails-i18n-vscode/raw/master/docs/hover.gif)

--- a/package.json
+++ b/package.json
@@ -16,10 +16,7 @@
         "Other"
     ],
     "activationEvents": [
-        "onLanguage:haml",
-        "onLanguage:erb",
-        "onLanguage:slim",
-        "onLanguage:ruby"
+        "workspaceContains:config/locales/**/*.yml"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -54,6 +51,11 @@
                     ],
                     "default": false,
                     "description": "load all translation files configured in I18n.load_path"
+                },
+                "railsI18n.languageIdentifiers": {
+                    "type": "string",
+                    "default": "haml,erb,slim,ruby",
+                    "description": "comma-separated list of language identifiers to scan for translation calls in. Valid identifiers can be found here: https://vscode-ppe.azurewebsites.net/docs/languages/identifiers"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -53,9 +53,18 @@
                     "description": "load all translation files configured in I18n.load_path"
                 },
                 "railsI18n.languageIdentifiers": {
-                    "type": "string",
-                    "default": "haml,erb,slim,ruby",
-                    "description": "comma-separated list of language identifiers to scan for translation calls in. Valid identifiers can be found here: https://vscode-ppe.azurewebsites.net/docs/languages/identifiers"
+                    "type": "array",
+                    "description": "A list of language identifiers to scan for translation calls in. Valid identifiers can be found here: https://vscode-ppe.azurewebsites.net/docs/languages/identifiers",
+                    "items": {
+                        "type": "string",
+                        "description": "A valid VSCode language identifier string"
+                    },
+                    "default": [
+                        "ruby",
+                        "erb",
+                        "haml",
+                        "slim"
+                    ]
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(i18nResolver);
     context.subscriptions.push(workspace.onDidChangeWorkspaceFolders(e => loadWithProgress()));
 
-    const fileTypes = vscode.workspace.getConfiguration('railsI18n').get<string>('languageIdentifiers').split(',');
+    const fileTypes = vscode.workspace.getConfiguration('railsI18n').get<Array<string>>('languageIdentifiers');
     const documentFilters = fileTypes.map(fileType => ({ language: fileType, scheme: 'file' }));
 
     context.subscriptions.push(vscode.languages.registerHoverProvider(documentFilters, new I18nHoverProvider()));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,12 +21,8 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(i18nResolver);
     context.subscriptions.push(workspace.onDidChangeWorkspaceFolders(e => loadWithProgress()));
 
-    const documentFilters = [
-        { language: 'haml', scheme: 'file' },
-        { language: 'erb', scheme: 'file' },
-        { language: 'slim', scheme: 'file' },
-        { language: 'ruby', scheme: 'file' },
-    ];
+    const fileTypes = vscode.workspace.getConfiguration('railsI18n').get<string>('languageIdentifiers').split(',');
+    const documentFilters = fileTypes.map(fileType => ({ language: fileType, scheme: 'file' }));
 
     context.subscriptions.push(vscode.languages.registerHoverProvider(documentFilters, new I18nHoverProvider()));
     context.subscriptions.push(vscode.languages.registerDefinitionProvider(documentFilters, new I18nDefinitionProvider()));


### PR DESCRIPTION
Thanks a lot for putting this extension together, it's been really helpful to me and the teams I've been on, however there is currently a gap, in that we cannot use it as-is to inspect translation calls that are in JavaScript.

However, because we use [i18n-js](https://github.com/fnando/i18n-js) which exposes the Rails translations to JS, and also uses Rails-like `t('path.to.translation')` syntax, this extension works well when we add support for the `javascript` and `javascriptreact` language identifiers.

I made this configurable, since it's reasonable to expect hardcoding these extra languages would not work for everyone, and there might be other languages that could benefit (like handlebars templates).

Here's the setting screen with support for the additional languages added:
![settings](https://user-images.githubusercontent.com/8360/56916424-d9939300-6a86-11e9-8064-1a0ec665b015.png)

Please let me know if there's anything I can do to improve this, or if there's another direction you'd like me to go with it.