### PR TITLE
Add support for copying keys in .yml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- add command to copy full i18n key on current cursor in yaml file
+
 ## 0.3.0
 - improve i18n call detection regex (dashed keys)
 - support block types in yaml

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "commands": [
             {
                 "command": "railsI18n.copyYamlKey",
-                "title": "Copy Key"
+                "title": "Copy I18n Key",
+                "enablement": "resourceLangId == yaml"
             }
         ],
         "menus": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/shanehofstetter/rails-i18n-vscode"
     },
     "engines": {
-        "vscode": "^1.24.0"
+        "vscode": "^1.30.0"
     },
     "categories": [
         "Other"
@@ -20,7 +20,20 @@
     ],
     "main": "./out/extension",
     "contributes": {
-        "commands": [],
+        "commands": [
+            {
+                "command": "railsI18n.copyYamlKey",
+                "title": "Copy Key"
+            }
+        ],
+        "menus": {
+            "editor/context": [
+                {
+                    "command": "railsI18n.copyYamlKey",
+                    "when": "resourceLangId == yaml"
+                }
+            ]
+        },
         "configuration": {
             "type": "object",
             "title": "Rails I18n",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,12 @@
+import { window, workspace, env } from 'vscode';
+import { i18nTree } from './i18nTree';
+
+export function copyYamlKey() {
+    const editor = window.activeTextEditor;
+    const startOffset = editor.document.offsetAt(editor.selection.start);
+    const workspaceFolder = workspace.getWorkspaceFolder(editor.document.uri);
+    const key = i18nTree.getFullKeyFromOffset(startOffset, editor.document.uri, workspaceFolder);
+    if (key) {
+        env.clipboard.writeText(key);
+    }
+};

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,5 +8,8 @@ export function copyYamlKey() {
     const key = i18nTree.getFullKeyFromOffset(startOffset, editor.document.uri, workspaceFolder);
     if (key) {
         env.clipboard.writeText(key);
+        window.showInformationMessage("I18n key copied to clipboard.")
+    } else {
+        window.showErrorMessage("I18n key could not be copied to clipboard!")
     }
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { I18nResolver } from './i18nResolver';
 import { I18nCompletionProvider } from './i18nCompletionProvider';
 import { workspace } from 'vscode';
 import { I18nDefinitionProvider } from './i18nDefinitionProvider';
+import { copyYamlKey } from './commands';
 
 export let i18nResolver = new I18nResolver();
 
@@ -29,4 +30,6 @@ export function activate(context: vscode.ExtensionContext) {
 
     const triggerCharacters = ".abcdefghijklmnopqrstuvwxyz".split("");
     context.subscriptions.push(vscode.languages.registerCompletionItemProvider(documentFilters, new I18nCompletionProvider(), ...triggerCharacters));
+
+    context.subscriptions.push(vscode.commands.registerCommand('railsI18n.copyYamlKey', copyYamlKey));
 }

--- a/src/i18nResolver.ts
+++ b/src/i18nResolver.ts
@@ -4,7 +4,8 @@ import { workspace, Uri, window } from 'vscode';
 import { DefaultLocaleDetector, LocaleDefaults } from './defaultLocaleDetector';
 import { logger } from "./logger";
 import { RailsCommands } from "./railsCommands";
-import { i18nTree, Translation } from "./i18nTree";
+import { i18nTree } from "./i18nTree";
+import { parseYAMLDocument } from "./yamlDocument";
 import { EventEmitter } from "events";
 
 export class I18nResolver implements vscode.Disposable {
@@ -89,7 +90,8 @@ export class I18nResolver implements vscode.Disposable {
                 if (!workspaceFolder) {
                     workspaceFolder = workspace.getWorkspaceFolder(file);
                 }
-                i18nTree.mergeIntoI18nTree(<Translation>YAML.parse(document.getText()), workspaceFolder, file);
+                const yamlDocument = YAML.parseDocument(document.getText());
+                i18nTree.mergeIntoI18nTree(parseYAMLDocument(yamlDocument), yamlDocument, workspaceFolder, file);
             } catch (error) {
                 logger.error('loadDocumentIntoMap', file.path, error.message);
             }

--- a/src/i18nResolver.ts
+++ b/src/i18nResolver.ts
@@ -1,12 +1,11 @@
-import YAML from "yaml";
 import * as vscode from 'vscode';
 import { workspace, Uri, window } from 'vscode';
 import { DefaultLocaleDetector, LocaleDefaults } from './defaultLocaleDetector';
 import { logger } from "./logger";
 import { RailsCommands } from "./railsCommands";
 import { i18nTree } from "./i18nTree";
-import { parseYAMLDocument } from "./yamlDocument";
 import { EventEmitter } from "events";
+import { YAMLDocument } from "./yamlDocument";
 
 export class I18nResolver implements vscode.Disposable {
 
@@ -90,8 +89,8 @@ export class I18nResolver implements vscode.Disposable {
                 if (!workspaceFolder) {
                     workspaceFolder = workspace.getWorkspaceFolder(file);
                 }
-                const yamlDocument = YAML.parseDocument(document.getText());
-                i18nTree.mergeIntoI18nTree(parseYAMLDocument(yamlDocument), yamlDocument, workspaceFolder, file);
+                const yamlDocument = YAMLDocument.parse(document.getText());
+                i18nTree.mergeIntoI18nTree(yamlDocument.toTranslation(), yamlDocument, workspaceFolder, file);
             } catch (error) {
                 logger.error('loadDocumentIntoMap', file.path, error.message);
             }

--- a/src/i18nTree.ts
+++ b/src/i18nTree.ts
@@ -43,6 +43,10 @@ export class I18nTree {
         return this.getOrCreateWorkspaceFolderTranslation(workspaceFolder).getTranslationPart(key, locale);
     }
 
+    public getFullKeyFromOffset(startOffset: number, file: Uri, workspaceFolder: WorkspaceFolder): string {
+        return this.getOrCreateWorkspaceFolderTranslation(workspaceFolder).getFullKeyFromOffset(startOffset, file);
+    }
+
     public getWorkspaceFolders(): WorkspaceFolder[] {
         return this.workspaceFolderTranslations.map((workspaceFolderTranslation) => workspaceFolderTranslation.workspaceFolder);
     }

--- a/src/i18nTree.ts
+++ b/src/i18nTree.ts
@@ -1,6 +1,7 @@
 import { logger } from "./logger";
 import { Uri, WorkspaceFolder } from "vscode";
 import { WorkspaceFolderTranslation, TranslationPart } from "./workspaceFolderTranslation";
+import { YAMLDocument } from "./yamlDocument";
 
 export type Translation = { [key: string]: string | Translation }
 export type LookupMap = { [key: string]: string }
@@ -12,8 +13,8 @@ export class I18nTree {
         this.workspaceFolderTranslations = [];
     }
 
-    public mergeIntoI18nTree(i18nTreePart: Translation, workspaceFolder: WorkspaceFolder, sourceFile?: Uri) {
-        this.getOrCreateWorkspaceFolderTranslation(workspaceFolder).mergeIntoI18nTree(i18nTreePart, sourceFile);
+    public mergeIntoI18nTree(i18nTreePart: Translation, yamlDocument: YAMLDocument, workspaceFolder: WorkspaceFolder, sourceFile?: Uri) {
+        this.getOrCreateWorkspaceFolderTranslation(workspaceFolder).mergeIntoI18nTree(i18nTreePart, yamlDocument, sourceFile);
     }
 
     public getKeysStartingWith(keyPart: string, workspaceFolder: WorkspaceFolder): string[] {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -34,7 +34,8 @@ describe("Extension", () => {
             globalState: null,
             extensionPath: '',
             asAbsolutePath: null,
-            storagePath: null
+            storagePath: null,
+            logPath: ''
         }
 
         beforeEach(() => {

--- a/src/test/i18nDefinitionProvider.test.ts
+++ b/src/test/i18nDefinitionProvider.test.ts
@@ -2,40 +2,11 @@ import * as assert from 'assert';
 import { I18nDefinitionProvider } from '../i18nDefinitionProvider';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import YAML from 'yaml';
-import { YAMLDocument } from '../yamlDocument';
 
 const i18nDefinitionProvider = new I18nDefinitionProvider();
 const fixtureDirectory =  path.join(__dirname, "..", "..", "src", "test", 'fixtures', 'config', 'locales');
 const yamlPath = path.join(fixtureDirectory, 'en.yml');
 const emptyYamlPath = path.join(fixtureDirectory, 'empty.yml');
-
-const yaml = `
-en:
-    hello: hello`;
-
-const yamlSingleQuoted = `
-en:
-    hello: 'hello'`;
-
-const yamlDoubleQuoted = `
-en:
-    hello: "hello"`;
-
-const yamlFlatKeys = `
-en:
-    hello.world: "hello"`;
-
-const yamlAllFlatKeys = `
-en.hello.world: "hello"`;
-
-const incompleteYaml = `
-en:
-    someotherkey: hello`;
-
-const toYAMLDocument = (text: string): YAMLDocument => {
-    return YAML.parseDocument(text);
-}
 
 describe("Definition Provider", () => {
     describe('findKeyValueLocationInDocument', () => {
@@ -62,64 +33,5 @@ describe("Definition Provider", () => {
                 done();
             })
         })
-    });
-
-    describe("findKeyValueRangeInYAML", () => {
-        context('when key is defined', () => {
-            it("returns correct range", () => {
-                assert.deepEqual(
-                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument(yaml), 'hello', 'en'),
-                    [16, 21]
-                );
-            });
-
-            it("finds singlequoted value", () => {
-                assert.deepEqual(
-                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument(yamlSingleQuoted), 'hello', 'en'),
-                    [16, 23]
-                );
-            });
-
-            it("finds doublequoted value", () => {
-                assert.deepEqual(
-                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument(yamlDoubleQuoted), 'hello', 'en'),
-                    [16, 23]
-                );
-            });
-
-            it("finds value with flat key", () => {
-                assert.deepEqual(
-                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument(yamlFlatKeys), 'hello.world', 'en'),
-                    [22, 29]
-                );
-            });
-
-            it("finds value with all flat keys", () => {
-                assert.deepEqual(
-                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument(yamlAllFlatKeys), 'hello.world', 'en'),
-                    [17, 24]
-                );
-            });
-        });
-
-        context('when key is not defined', () => {
-            it('returns null', () => {
-                assert.equal(
-                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument('en:'), 'hello', 'en'),
-                    null,
-                    'handles yaml document without any keys'
-                );
-                assert.equal(
-                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument(incompleteYaml), 'hello', 'en'),
-                    null,
-                    'handles valid document without target key'
-                );
-                assert.equal(
-                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument(yaml), 'hello', 'de'),
-                    null,
-                    'handles valid document without target key'
-                );
-            });
-        });
     });
 });

--- a/src/test/i18nDefinitionProvider.test.ts
+++ b/src/test/i18nDefinitionProvider.test.ts
@@ -2,9 +2,13 @@ import * as assert from 'assert';
 import { I18nDefinitionProvider } from '../i18nDefinitionProvider';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import YAML from 'yaml';
+import { YAMLDocument } from '../yamlDocument';
 
 const i18nDefinitionProvider = new I18nDefinitionProvider();
-const yamlPath = path.join(__dirname, "..", "..", "src", "test", 'fixtures', 'config', 'locales', 'en.yml');
+const fixtureDirectory =  path.join(__dirname, "..", "..", "src", "test", 'fixtures', 'config', 'locales');
+const yamlPath = path.join(fixtureDirectory, 'en.yml');
+const emptyYamlPath = path.join(fixtureDirectory, 'empty.yml');
 
 const yaml = `
 en:
@@ -29,10 +33,14 @@ const incompleteYaml = `
 en:
     someotherkey: hello`;
 
+const toYAMLDocument = (text: string): YAMLDocument => {
+    return YAML.parseDocument(text);
+}
+
 describe("Definition Provider", () => {
     describe('findKeyValueLocationInDocument', () => {
         it('returns the correct range', (done) => {
-            const uri = vscode.Uri.file(yamlPath)
+            const uri = vscode.Uri.file(yamlPath);
             i18nDefinitionProvider.findKeyValueLocationInDocument(uri, 'hello', 'en').then(location => {
                 assert.equal(location.uri, uri);
                 assert.equal(location.range.start.line, 1);
@@ -43,41 +51,52 @@ describe("Definition Provider", () => {
                 done();
             })
         });
+
+        it('returns null when file is empty', (done) => {
+            const uri = vscode.Uri.file(emptyYamlPath);
+            i18nDefinitionProvider.findKeyValueLocationInDocument(uri, 'hello', 'en').then(location => {
+                assert.equal(location, null);
+                done();
+            }, error => {
+                assert.fail(null, null, error);
+                done();
+            })
+        })
     });
 
     describe("findKeyValueRangeInYAML", () => {
         context('when key is defined', () => {
             it("returns correct range", () => {
                 assert.deepEqual(
-                    i18nDefinitionProvider.findKeyValueRangeInYAML(yaml, 'hello', 'en'),
+                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument(yaml), 'hello', 'en'),
                     [16, 21]
                 );
             });
 
             it("finds singlequoted value", () => {
                 assert.deepEqual(
-                    i18nDefinitionProvider.findKeyValueRangeInYAML(yamlSingleQuoted, 'hello', 'en'),
+                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument(yamlSingleQuoted), 'hello', 'en'),
                     [16, 23]
                 );
             });
 
             it("finds doublequoted value", () => {
                 assert.deepEqual(
-                    i18nDefinitionProvider.findKeyValueRangeInYAML(yamlDoubleQuoted, 'hello', 'en'),
+                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument(yamlDoubleQuoted), 'hello', 'en'),
                     [16, 23]
                 );
             });
 
             it("finds value with flat key", () => {
                 assert.deepEqual(
-                    i18nDefinitionProvider.findKeyValueRangeInYAML(yamlFlatKeys, 'hello.world', 'en'),
+                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument(yamlFlatKeys), 'hello.world', 'en'),
                     [22, 29]
                 );
             });
 
             it("finds value with all flat keys", () => {
                 assert.deepEqual(
-                    i18nDefinitionProvider.findKeyValueRangeInYAML(yamlAllFlatKeys, 'hello.world', 'en'),
+                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument(yamlAllFlatKeys), 'hello.world', 'en'),
                     [17, 24]
                 );
             });
@@ -85,10 +104,21 @@ describe("Definition Provider", () => {
 
         context('when key is not defined', () => {
             it('returns null', () => {
-                assert.equal(i18nDefinitionProvider.findKeyValueRangeInYAML('', 'hello', 'en'), null, 'handles empty yaml document');
-                assert.equal(i18nDefinitionProvider.findKeyValueRangeInYAML('en:', 'hello', 'en'), null, 'handles yaml document without any keys');
-                assert.equal(i18nDefinitionProvider.findKeyValueRangeInYAML(incompleteYaml, 'hello', 'en'), null, 'handles valid document without target key');
-                assert.equal(i18nDefinitionProvider.findKeyValueRangeInYAML(yaml, 'hello', 'de'), null, 'handles valid document without target key');
+                assert.equal(
+                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument('en:'), 'hello', 'en'),
+                    null,
+                    'handles yaml document without any keys'
+                );
+                assert.equal(
+                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument(incompleteYaml), 'hello', 'en'),
+                    null,
+                    'handles valid document without target key'
+                );
+                assert.equal(
+                    i18nDefinitionProvider.findKeyValueRangeInYamlDocument(toYAMLDocument(yaml), 'hello', 'de'),
+                    null,
+                    'handles valid document without target key'
+                );
             });
         });
     });

--- a/src/test/i18nTree.test.ts
+++ b/src/test/i18nTree.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import { I18nTree } from '../i18nTree';
 import { WorkspaceFolder, Uri } from 'vscode';
+import { YAMLDocument } from '../yamlDocument';
 
 describe("I18nTree", () => {
     const blogWorkspaceFolder: WorkspaceFolder = {
@@ -13,6 +14,11 @@ describe("I18nTree", () => {
         uri: Uri.file('/xy'),
         index: 1
     }
+    const yamlDocument: YAMLDocument = {
+        contents: { items: [] },
+        errors: [],
+        toJSON: function(arg?: any) {}
+    }
 
     beforeEach(() => {
         this.i18nTree = new I18nTree();
@@ -21,7 +27,7 @@ describe("I18nTree", () => {
     describe("init", () => {
         context("when translations loaded", () => {
             beforeEach(() => {
-                this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, blogWorkspaceFolder)
+                this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, yamlDocument, blogWorkspaceFolder)
             });
 
             it("resets translations", () => {
@@ -42,12 +48,12 @@ describe("I18nTree", () => {
         beforeEach(() => { this.i18nTree.init(); });
 
         it('does not remove existing translations', () => {
-            this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, blogWorkspaceFolder)
+            this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, yamlDocument, blogWorkspaceFolder)
             assert.equal(
                 this.i18nTree.lookupKey('en.hello', blogWorkspaceFolder),
                 'hi'
             );
-            this.i18nTree.mergeIntoI18nTree({ en: { bye: 'bye' } }, blogWorkspaceFolder)
+            this.i18nTree.mergeIntoI18nTree({ en: { bye: 'bye' } }, yamlDocument, blogWorkspaceFolder)
             assert.equal(
                 this.i18nTree.lookupKey('en.hello', blogWorkspaceFolder),
                 'hi'
@@ -60,11 +66,11 @@ describe("I18nTree", () => {
 
         context('when sourceFile is specified', () => {
             it('does not keep no longer existing keys', () => {
-                this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, blogWorkspaceFolder, Uri.file('/file/a'));
-                this.i18nTree.mergeIntoI18nTree({ en: { bye: 'bye' } }, blogWorkspaceFolder, Uri.file('/file/b'));
+                this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, yamlDocument, blogWorkspaceFolder, Uri.file('/file/a'));
+                this.i18nTree.mergeIntoI18nTree({ en: { bye: 'bye' } }, yamlDocument, blogWorkspaceFolder, Uri.file('/file/b'));
                 assert.equal(this.i18nTree.lookupKey('en.hello', blogWorkspaceFolder), 'hi');
                 assert.equal(this.i18nTree.lookupKey('en.bye', blogWorkspaceFolder), 'bye');
-                this.i18nTree.mergeIntoI18nTree({ en: { ciao: 'ciao' } }, blogWorkspaceFolder, Uri.file('/file/a'));
+                this.i18nTree.mergeIntoI18nTree({ en: { ciao: 'ciao' } }, yamlDocument, blogWorkspaceFolder, Uri.file('/file/a'));
                 assert.equal(this.i18nTree.lookupKey('en.hello', blogWorkspaceFolder), undefined);
                 assert.equal(this.i18nTree.lookupKey('en.ciao', blogWorkspaceFolder), 'ciao');
             });
@@ -75,7 +81,7 @@ describe("I18nTree", () => {
         beforeEach(() => { this.i18nTree.init(); });
 
         it('returns keys which begin with substring', () => {
-            this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi', help: 'help', bye: 'bye' } }, blogWorkspaceFolder)
+            this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi', help: 'help', bye: 'bye' } }, yamlDocument, blogWorkspaceFolder)
             assert.deepStrictEqual(
                 this.i18nTree.getKeysStartingWith('en.he', blogWorkspaceFolder),
                 [
@@ -91,19 +97,19 @@ describe("I18nTree", () => {
 
         context('when translations exist', () => {
             it('returns true', () => {
-                this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, blogWorkspaceFolder)
+                this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, yamlDocument, blogWorkspaceFolder)
                 assert.equal(this.i18nTree.translationsForLocaleExist('en', blogWorkspaceFolder), true);
             });
         });
 
         context('when no translations exist', () => {
             it('returns false if no translations for workspace folder available', () => {
-                this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, blogWorkspaceFolder)
+                this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, yamlDocument, blogWorkspaceFolder)
                 assert.equal(this.i18nTree.translationsForLocaleExist('en', xyWorkspaceFolder), false);
             });
 
             it('returns false if no translations for workspace folder and locale available', () => {
-                this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, blogWorkspaceFolder)
+                this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, yamlDocument, blogWorkspaceFolder)
                 assert.equal(this.i18nTree.translationsForLocaleExist('fr', blogWorkspaceFolder), false);
             });
         });
@@ -113,17 +119,17 @@ describe("I18nTree", () => {
         beforeEach(() => { this.i18nTree.init(); });
 
         it('returns first locale of workspacefolder translations', () => {
-            this.i18nTree.mergeIntoI18nTree({ fr: { hello: 'hi' }, it: { hello: 'hi' } }, blogWorkspaceFolder)
+            this.i18nTree.mergeIntoI18nTree({ fr: { hello: 'hi' }, it: { hello: 'hi' } }, yamlDocument, blogWorkspaceFolder)
             assert.equal(this.i18nTree.getFallbackLocale(blogWorkspaceFolder), 'fr');
         });
 
         it('returns en if no translations for workspace folder loaded', () => {
-            this.i18nTree.mergeIntoI18nTree({}, blogWorkspaceFolder)
+            this.i18nTree.mergeIntoI18nTree({}, yamlDocument, blogWorkspaceFolder)
             assert.equal(this.i18nTree.getFallbackLocale(blogWorkspaceFolder), 'en');
         });
 
         it('returns en if workspace folder not present in translations', () => {
-            this.i18nTree.mergeIntoI18nTree({}, xyWorkspaceFolder)
+            this.i18nTree.mergeIntoI18nTree({}, yamlDocument, xyWorkspaceFolder)
             assert.equal(this.i18nTree.getFallbackLocale(blogWorkspaceFolder), 'en');
         });
     });
@@ -133,13 +139,14 @@ describe("I18nTree", () => {
 
         context('with translations for workspace', () => {
             it('returns string translation', () => {
-                this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, blogWorkspaceFolder);
+                this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, yamlDocument, blogWorkspaceFolder);
                 assert.equal(this.i18nTree.getTranslation('hello', 'en', blogWorkspaceFolder), 'hi');
             });
 
             it('returns multiresult', () => {
                 this.i18nTree.mergeIntoI18nTree(
                     { en: { greetings: { hi: 'hi', hello: 'hello' } } },
+                    yamlDocument,
                     blogWorkspaceFolder);
                 assert.equal(this.i18nTree.getTranslation('greetings', 'en', blogWorkspaceFolder),
                     'hi: hi\nhello: hello');
@@ -163,10 +170,10 @@ describe("I18nTree", () => {
 
     describe('getWorkspaceFolderNames', () => {
         it('returns list of workspace folder names', () => {
-            this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, blogWorkspaceFolder);
+            this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, yamlDocument, blogWorkspaceFolder);
             assert.deepStrictEqual(this.i18nTree.getWorkspaceFolders(), [blogWorkspaceFolder]);
-            this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, blogWorkspaceFolder);
-            this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, xyWorkspaceFolder);
+            this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, yamlDocument, blogWorkspaceFolder);
+            this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, yamlDocument, xyWorkspaceFolder);
             assert.deepStrictEqual(this.i18nTree.getWorkspaceFolders(), [blogWorkspaceFolder, xyWorkspaceFolder]);
         });
 
@@ -177,7 +184,7 @@ describe("I18nTree", () => {
 
     describe('lookupKey', () => {
         it('returns translation for given full key', () => {
-            this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, blogWorkspaceFolder);
+            this.i18nTree.mergeIntoI18nTree({ en: { hello: 'hi' } }, yamlDocument, blogWorkspaceFolder);
             assert.equal(this.i18nTree.lookupKey('en.hello', blogWorkspaceFolder), 'hi');
         });
 

--- a/src/test/i18nTree.test.ts
+++ b/src/test/i18nTree.test.ts
@@ -14,11 +14,7 @@ describe("I18nTree", () => {
         uri: Uri.file('/xy'),
         index: 1
     }
-    const yamlDocument: YAMLDocument = {
-        contents: { items: [] },
-        errors: [],
-        toJSON: function(arg?: any) {}
-    }
+    const yamlDocument: YAMLDocument = new YAMLDocument({})
 
     beforeEach(() => {
         this.i18nTree = new I18nTree();

--- a/src/test/yamlDocument.test.ts
+++ b/src/test/yamlDocument.test.ts
@@ -91,27 +91,27 @@ describe("YAMLDocument", () => {
     });
 
     describe('getFullKeyFromOffset', () => {
-        it('returns only the first part of the key when first line is selected', () => {
-            assert.equal(YAMLDocument.parse(yaml).getFullKeyFromOffset(1), 'en');
+        it('returns empty string when first line is selected, does not include locale', () => {
+            assert.equal(YAMLDocument.parse(yaml).getFullKeyFromOffset(1), '');
         });
 
         it('returns multiple parts of key, up to and including selected key', () => {
-            assert.equal(YAMLDocument.parse(yaml).getFullKeyFromOffset(9), 'en.hello');
+            assert.equal(YAMLDocument.parse(yaml).getFullKeyFromOffset(9), 'hello');
         });
 
         context('with flat-key', () => {
             it('returns full flat key if only prefix portion is selected', () => {
-                assert.equal(YAMLDocument.parse(yamlAllFlatKeys).getFullKeyFromOffset(5), 'en.hello.world');
+                assert.equal(YAMLDocument.parse(yamlAllFlatKeys).getFullKeyFromOffset(5), 'hello.world');
             });
 
             it('returns the full flat key if final part is selected', () => {
-                assert.equal(YAMLDocument.parse(yamlAllFlatKeys).getFullKeyFromOffset(15), 'en.hello.world');
+                assert.equal(YAMLDocument.parse(yamlAllFlatKeys).getFullKeyFromOffset(15), 'hello.world');
             });
         });
 
         context('with multi-key file', () => {
             it('returns expected key', () => {
-                assert.equal(YAMLDocument.parse(multiKeyYaml).getFullKeyFromOffset(50), 'en.otherkey.morenesting');
+                assert.equal(YAMLDocument.parse(multiKeyYaml).getFullKeyFromOffset(50), 'otherkey.morenesting');
             });
         });
     });

--- a/src/test/yamlDocument.test.ts
+++ b/src/test/yamlDocument.test.ts
@@ -1,0 +1,118 @@
+import * as assert from 'assert';
+import { YAMLDocument } from '../yamlDocument';
+
+const yaml = `
+en:
+    hello: hello`;
+
+const yamlSingleQuoted = `
+en:
+    hello: 'hello'`;
+
+const yamlDoubleQuoted = `
+en:
+    hello: "hello"`;
+
+const yamlFlatKeys = `
+en:
+    hello.world: "hello"`;
+
+const yamlAllFlatKeys = `
+en.hello.world: "hello"`;
+
+const incompleteYaml = `
+en:
+    someotherkey: hello`;
+
+const multiKeyYaml = `
+en:
+    somekey: foo
+    otherkey:
+        morenesting: bar`;
+
+describe("YAMLDocument", () => {
+    describe("findKeyValueRange", () => {
+        context('when key is defined', () => {
+            it("returns correct range", () => {
+                assert.deepEqual(
+                    YAMLDocument.parse(yaml).findKeyValueRange('hello', 'en'),
+                    [16, 21]
+                );
+            });
+
+            it("finds singlequoted value", () => {
+                assert.deepEqual(
+                    YAMLDocument.parse(yamlSingleQuoted).findKeyValueRange('hello', 'en'),
+                    [16, 23]
+                );
+            });
+
+            it("finds doublequoted value", () => {
+                assert.deepEqual(
+                    YAMLDocument.parse(yamlDoubleQuoted).findKeyValueRange('hello', 'en'),
+                    [16, 23]
+                );
+            });
+
+            it("finds value with flat key", () => {
+                assert.deepEqual(
+                    YAMLDocument.parse(yamlFlatKeys).findKeyValueRange('hello.world', 'en'),
+                    [22, 29]
+                );
+            });
+
+            it("finds value with all flat keys", () => {
+                assert.deepEqual(
+                    YAMLDocument.parse(yamlAllFlatKeys).findKeyValueRange('hello.world', 'en'),
+                    [17, 24]
+                );
+            });
+        });
+
+        context('when key is not defined', () => {
+            it('returns null', () => {
+                assert.equal(
+                    YAMLDocument.parse('en:').findKeyValueRange('hello', 'en'),
+                    null,
+                    'handles yaml document without any keys'
+                );
+                assert.equal(
+                    YAMLDocument.parse(incompleteYaml).findKeyValueRange('hello', 'en'),
+                    null,
+                    'handles valid document without target key'
+                );
+                assert.equal(
+                    YAMLDocument.parse(yaml).findKeyValueRange('hello', 'de'),
+                    null,
+                    'handles valid document without target key'
+                );
+            });
+        });
+    });
+
+    describe('getFullKeyFromOffset', () => {
+        it('returns only the first part of the key when first line is selected', () => {
+            assert.equal(YAMLDocument.parse(yaml).getFullKeyFromOffset(1), 'en');
+        });
+
+        it('returns multiple parts of key, up to and including selected key', () => {
+            assert.equal(YAMLDocument.parse(yaml).getFullKeyFromOffset(9), 'en.hello');
+        });
+
+        context('with flat-key', () => {
+            it('returns full flat key if only prefix portion is selected', () => {
+                assert.equal(YAMLDocument.parse(yamlAllFlatKeys).getFullKeyFromOffset(5), 'en.hello.world');
+            });
+
+            it('returns the full flat key if final part is selected', () => {
+                assert.equal(YAMLDocument.parse(yamlAllFlatKeys).getFullKeyFromOffset(15), 'en.hello.world');
+            });
+        });
+
+        context('with multi-key file', () => {
+            it('returns expected key', () => {
+                assert.equal(YAMLDocument.parse(multiKeyYaml).getFullKeyFromOffset(50), 'en.otherkey.morenesting');
+            });
+        });
+    });
+});

--- a/src/workspaceFolderTranslation.ts
+++ b/src/workspaceFolderTranslation.ts
@@ -3,8 +3,9 @@ import { Translation, LookupMap } from "./i18nTree";
 import { LookupMapGenerator } from "./lookupMapGenerator";
 import { logger } from "./logger";
 import * as merge from "merge";
+import { YAMLDocument } from "./yamlDocument";
 
-export type TranslationPart = { file: Uri, translations: Translation }
+export type TranslationPart = { file: Uri, translations: Translation, yamlDocument: YAMLDocument }
 
 export class WorkspaceFolderTranslation {
     public workspaceFolder: WorkspaceFolder;
@@ -16,8 +17,8 @@ export class WorkspaceFolderTranslation {
         this.workspaceFolder = workspaceFolder;
     }
 
-    public mergeIntoI18nTree(i18nTreePart: Translation, sourceFile?: Uri) {
-        this.addTranslationPart(i18nTreePart, sourceFile || null);
+    public mergeIntoI18nTree(i18nTreePart: Translation, yamlDocument: YAMLDocument, sourceFile?: Uri) {
+        this.addTranslationPart(i18nTreePart, yamlDocument, sourceFile || null);
         this.translation = {};
         this.translationParts.forEach((translationPart) => {
             this.translation = merge.recursive(
@@ -65,7 +66,7 @@ export class WorkspaceFolderTranslation {
         if (['string', 'number', 'boolean'].indexOf(typeof simpleLookupResult) >= 0) return simpleLookupResult.toString();
         if (simpleLookupResult === null) return "null"; // special case when null is defined as translation
 
-        // if simpleLookupResult returned undefined (not found) or some other unknown type, 
+        // if simpleLookupResult returned undefined (not found) or some other unknown type,
         // this could mean that only a part of the key is given.
         // try to find the resulting sub-tree and return that instead (converted to text).
 
@@ -79,7 +80,7 @@ export class WorkspaceFolderTranslation {
     }
 
     /**
-     * find the translation part containing given key (first match is returned) 
+     * find the translation part containing given key (first match is returned)
      * @param key i18n key
      * @param locale locale key
      */
@@ -94,8 +95,8 @@ export class WorkspaceFolderTranslation {
         return this.lookupMap[key];
     }
 
-    private addTranslationPart(translation: Translation, sourceFile: Uri) {
-        const translationPart = { translations: translation, file: sourceFile };
+    private addTranslationPart(translation: Translation, yamlDocument: YAMLDocument, sourceFile: Uri) {
+        const translationPart = { translations: translation, yamlDocument: yamlDocument, file: sourceFile };
         if (this.translationParts.length > 0 && translationPart.file) {
             this.translationParts = this.translationParts.filter(tp => tp.file && tp.file.path !== translationPart.file.path);
         }
@@ -133,8 +134,8 @@ export class WorkspaceFolderTranslation {
     }
 
     private transformMultiResultIntoText(result: object): string {
-        // if last part of i18n key is missing (e.g. because its interpolated), 
-        // we can still show a list of possible translations 
+        // if last part of i18n key is missing (e.g. because its interpolated),
+        // we can still show a list of possible translations
         let resultLines = [];
         Object.keys(result).forEach(key => {
             let text = result[key];

--- a/src/workspaceFolderTranslation.ts
+++ b/src/workspaceFolderTranslation.ts
@@ -4,7 +4,6 @@ import { LookupMapGenerator } from "./lookupMapGenerator";
 import { logger } from "./logger";
 import * as merge from "merge";
 import { YAMLDocument } from "./yamlDocument";
-import { start } from "repl";
 
 export type TranslationPart = { file: Uri, translations: Translation, yamlDocument: YAMLDocument }
 
@@ -127,7 +126,7 @@ export class WorkspaceFolderTranslation {
 
     private addTranslationPart(translation: Translation, yamlDocument: YAMLDocument, sourceFile: Uri): TranslationPart {
         const translationPart = { translations: translation, yamlDocument: yamlDocument, file: sourceFile };
-      
+
         if (this.translationParts.length > 0 && translationPart.file) {
             this.translationParts = this.translationParts.filter(tp => tp.file && tp.file.path !== translationPart.file.path);
         }

--- a/src/workspaceFolderTranslation.ts
+++ b/src/workspaceFolderTranslation.ts
@@ -4,6 +4,7 @@ import { LookupMapGenerator } from "./lookupMapGenerator";
 import { logger } from "./logger";
 import * as merge from "merge";
 import { YAMLDocument } from "./yamlDocument";
+import { start } from "repl";
 
 export type TranslationPart = { file: Uri, translations: Translation, yamlDocument: YAMLDocument }
 
@@ -89,6 +90,15 @@ export class WorkspaceFolderTranslation {
             const result = this.traverseTranslation(this.makeKeyParts(key, locale), translationPart.translations);
             return typeof result === "string";
         });
+    }
+
+    public getFullKeyFromOffset(startOffset: number, file: Uri): string {
+        const translationPart = this.translationParts.find(tp => tp.file && tp.file.path === file.path);
+        if (!translationPart || !translationPart.yamlDocument) {
+            return null;
+        }
+
+        return translationPart.yamlDocument.getFullKeyFromOffset(startOffset);
     }
 
     public lookupKey(key: string): any {

--- a/src/yamlDocument.ts
+++ b/src/yamlDocument.ts
@@ -1,0 +1,17 @@
+import { Translation } from "./i18nTree";
+
+export interface YAMLDocument {
+    contents: { items: YAMLDocumentItem[] };
+    errors: Array<any>;
+    toJSON(arg?: any);
+}
+
+export interface YAMLDocumentItem {
+    stringKey: string;
+    value: any;
+}
+
+export function parseYAMLDocument(document: YAMLDocument): Translation {
+    if (document.errors.length > 0) throw document.errors[0]
+    return document.toJSON()
+}

--- a/src/yamlDocument.ts
+++ b/src/yamlDocument.ts
@@ -1,17 +1,141 @@
 import { Translation } from "./i18nTree";
+import { logger } from "./logger";
+import YAML from "yaml";
 
-export interface YAMLDocument {
-    contents: { items: YAMLDocumentItem[] };
+export interface ParsedDocument {
+    contents: { items: ParsedDocumentItem[] };
     errors: Array<any>;
     toJSON(arg?: any);
 }
 
-export interface YAMLDocumentItem {
+export interface ParsedDocumentItem {
     stringKey: string;
     value: any;
 }
 
-export function parseYAMLDocument(document: YAMLDocument): Translation {
-    if (document.errors.length > 0) throw document.errors[0]
-    return document.toJSON()
+const SCALAR_TYPES = ['PLAIN', 'QUOTE_DOUBLE', 'QUOTE_SINGLE', 'BLOCK_FOLDED', 'BLOCK_LITERAL'];
+const PAIR_TYPES = ['PAIR'];
+
+export class YAMLDocument {
+    parsedDocument: any;
+
+    public static parse(text: string): YAMLDocument {
+        const parsedDocument = YAML.parseDocument(text);
+        if (parsedDocument.errors.length > 0) {
+            throw parsedDocument.errors[0];
+        }
+
+        return new YAMLDocument(parsedDocument);
+    }
+
+    constructor(parsedDocument: any) {
+        this.parsedDocument = parsedDocument;
+    }
+
+    public toTranslation(): Translation {
+        return this.parsedDocument.toJSON();
+    }
+
+    public findKeyValueRange(absoluteKey: string, locale: string): number[] {
+        logger.debug('findKeyValueRange', { absoluteKey, locale });
+
+        const keyParts: string[] = absoluteKey.split('.').filter(key => key.length > 0);
+
+        let yamlPairs = this.parsedDocument.contents.items;
+        if (!yamlPairs) {
+            logger.warn('yamlDocument does not have any items');
+            return null;
+        }
+
+        keyParts.unshift(locale);
+
+        for (let i = 0; i < keyParts.length; i++) {
+            const keyPart = keyParts[i];
+            const flatKey: string = keyParts.slice(i).join('.');
+            let yamlPair = yamlPairs.find(item => item.stringKey === flatKey);
+            if (!yamlPair) {
+                yamlPair = yamlPairs.find(item => item.stringKey === keyPart);
+                if (!yamlPair) {
+                    logger.debug('key could not be located in yaml document');
+                    return null;
+                }
+            }
+            let value = yamlPair.value;
+            logger.debug('current value:', value, 'typeof value', typeof value);
+
+            if (typeof value !== 'object') {
+                logger.debug('unknown value object (not an object)', { value });
+                return null;
+            }
+
+            if (SCALAR_TYPES.indexOf(value.type) >= 0) {
+                logger.debug('findKeyValueRangeInYamlDocument', { value });
+                return value.range;
+            } else if (value.items) {
+                yamlPairs = value.items;
+            } else {
+                logger.debug('unknown value object (complex type with no child items)', { ...value });
+                return null;
+            }
+        }
+        return null;
+    }
+
+    public getFullKeyFromOffset(startOffset: number): string {
+        let keyParts = [];
+
+        this.findRemainingKeyParts(this.parsedDocument.contents, startOffset, true, keyParts);
+        return keyParts.join('.');
+    }
+
+    private findRemainingKeyParts(node: any, targetOffset: number, validateRange: boolean, keyParts: Array<string>): boolean {
+        const nodeRange = this.nodeRange(node);
+
+        if (validateRange && !this.rangeCovers(nodeRange, targetOffset)) {
+            return false;
+        }
+
+        let match = false;
+        if (this.isPairNode(node)) {
+            this.findRemainingKeyParts(node.key, targetOffset, false, keyParts);
+            match = match || this.findRemainingKeyParts(node.value, targetOffset, true, keyParts);
+        }
+        else if (SCALAR_TYPES.indexOf(node.type) >= 0 && node.value) {
+            keyParts.push(node.value);
+            match = true;
+        }
+        else if (node.items) {
+            for (let item of node.items) {
+                match = match || this.findRemainingKeyParts(item, targetOffset, true, keyParts);
+                if (match) {
+                    break;
+                }
+            }
+        }
+
+        return match;
+    }
+
+    private nodeRange(node: any) {
+        const pairNode = this.isPairNode(node);
+        if (pairNode) {
+            const keyRange = node.key && node.key.range || [];
+            const valueRange = node.value && node.value.range || [];
+            const adjustedRange = [Math.min(...keyRange, ...valueRange), Math.max(...keyRange, ...valueRange)];
+
+            if (isFinite(adjustedRange[0]) && isFinite(adjustedRange[1])) {
+                return adjustedRange;
+            }
+        }
+
+        return node.range;
+    }
+
+    private isPairNode(node: any) {
+        return PAIR_TYPES.indexOf(node.type) >= 0;
+    }
+
+    private rangeCovers(range: any, value: number) {
+        return range[0] <= value && range[1] >= value;
+    }
 }

--- a/src/yamlDocument.ts
+++ b/src/yamlDocument.ts
@@ -106,7 +106,7 @@ export class YAMLDocument {
             }
         }
         else if (this.isScalarNode(node) && node.value) {
-            keyParts.push(node.value);
+            keyParts.push(...node.value.split('.'));
             match = true;
         }
         else if (node.items) {

--- a/src/yamlDocument.ts
+++ b/src/yamlDocument.ts
@@ -85,7 +85,7 @@ export class YAMLDocument {
         let keyParts = [];
 
         this.findRemainingKeyParts(this.parsedDocument.contents, startOffset, true, keyParts);
-        return keyParts.join('.');
+        return keyParts.slice(1).join('.'); // remove first key part, i.e. the locale
     }
 
     private findRemainingKeyParts(node: any, targetOffset: number, validateRange: boolean, keyParts: Array<string>): boolean {

--- a/src/yamlDocument.ts
+++ b/src/yamlDocument.ts
@@ -98,9 +98,14 @@ export class YAMLDocument {
         let match = false;
         if (this.isPairNode(node)) {
             this.findRemainingKeyParts(node.key, targetOffset, false, keyParts);
-            match = match || this.findRemainingKeyParts(node.value, targetOffset, true, keyParts);
+            if (this.isScalarNode(node.value)) {
+                // stop if value is a scalar, i.e. the translation text
+                match = true;
+            } else {
+                match = match || this.findRemainingKeyParts(node.value, targetOffset, true, keyParts);
+            }
         }
-        else if (SCALAR_TYPES.indexOf(node.type) >= 0 && node.value) {
+        else if (this.isScalarNode(node) && node.value) {
             keyParts.push(node.value);
             match = true;
         }
@@ -113,6 +118,7 @@ export class YAMLDocument {
             }
         }
 
+        console.log("match", match, keyParts);
         return match;
     }
 
@@ -133,6 +139,10 @@ export class YAMLDocument {
 
     private isPairNode(node: any) {
         return PAIR_TYPES.indexOf(node.type) >= 0;
+    }
+
+    private isScalarNode(node: any) {
+        return SCALAR_TYPES.indexOf(node.type) >= 0;
     }
 
     private rangeCovers(range: any, value: number) {

--- a/src/yamlDocument.ts
+++ b/src/yamlDocument.ts
@@ -118,7 +118,6 @@ export class YAMLDocument {
             }
         }
 
-        console.log("match", match, keyParts);
         return match;
     }
 


### PR DESCRIPTION
Hey, I sketched out a command for copying the full text of a YAML key. I marked it WIP because I plan to add more tests and wanted to check in to see how you think the UI ought to work before I did anymore work (i.e. what should behavior be if cursor is over a value or whitespace rather than a key?). Will also need to strip the locale from the key and other little things like that.

Let me know what you think. I'll annotate/call out stuff in the PR that might be of interest. 

Also, there was also a spec for me when I compiled locally (before making any changes). Not sure if it's just failing for my setup, but I can look into that as well.